### PR TITLE
Add ability to include span events in logging output

### DIFF
--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -1,8 +1,12 @@
+use tracing_subscriber::fmt::format::FmtSpan;
 use tracing_subscriber::prelude::*;
 use tracing_subscriber::{fmt, EnvFilter};
 
 pub fn init_tracing() {
-    let fmt_layer = fmt::layer().with_target(false);
+    let mut fmt_layer = fmt::layer();
+    if std::env::var("INCLUDE_SPAN_EVENTS").is_ok_and(|value| value.eq_ignore_ascii_case("true")) {
+        fmt_layer = fmt_layer.with_span_events(FmtSpan::ENTER | FmtSpan::EXIT);
+    }
     let filter_layer = EnvFilter::try_from_default_env()
         .or_else(|_| EnvFilter::try_new("info"))
         .unwrap();


### PR DESCRIPTION
Span events are a bit noisy, so they are disabled by default for now